### PR TITLE
Consider files with the 'cjsx' extension test spec candidates.

### DIFF
--- a/src/client/integration/ClientIntegrationTestFramework.js
+++ b/src/client/integration/ClientIntegrationTestFramework.js
@@ -5,7 +5,7 @@ ClientIntegrationTestFramework = function (options) {
 
   _.defaults(options, {
     name: 'jasmine-client-integration',
-    regex: '^tests/jasmine/client/integration/.+\\.(js|es6|jsx|coffee|litcoffee|coffee\\.md)$',
+    regex: '^tests/jasmine/client/integration/.+\\.(js|es6|jsx|coffee|cjsx|litcoffee|coffee\\.md)$',
     sampleTestGenerator: function () {
       return [
         {

--- a/src/server/integration/ServerIntegrationTestFramework.js
+++ b/src/server/integration/ServerIntegrationTestFramework.js
@@ -74,7 +74,7 @@ ServerIntegrationTestFramework = function (options) {
 
   _.defaults(options, {
     name: 'jasmine-server-integration',
-    regex: '^tests/jasmine/server/integration/.+\\.(js|es6|jsx|coffee|litcoffee|coffee\\.md)$',
+    regex: '^tests/jasmine/server/integration/.+\\.(js|es6|jsx|coffee|cjsx|litcoffee|coffee\\.md)$',
     sampleTestGenerator: function () {
       return [
         {


### PR DESCRIPTION
CJSX is the coffee-script variant of JSX, see https://github.com/jsdf/coffee-react. When Meteor is configured with meteor-cjsx (https://github.com/jhartma/meteor-cjsx) it is possible to write tests in the cjsx language.